### PR TITLE
RHEL (like Amazon) uses '6Server': override to '6'

### DIFF
--- a/attributes/erlang_solutions.rb
+++ b/attributes/erlang_solutions.rb
@@ -1,5 +1,5 @@
 case node['platform']
-when 'amazon'
+when 'amazon', 'redhat'
   default['yum']['erlang_solutions']['baseurl'] = 'http://packages.erlang-solutions.com/rpm/centos/6/$basearch'
 else
   default['yum']['erlang_solutions']['baseurl'] = 'http://packages.erlang-solutions.com/rpm/centos/$releasever/$basearch'


### PR DESCRIPTION
This fixes compatibility with the RHEL image on AWS.
